### PR TITLE
フォームオブジェクト

### DIFF
--- a/app/forms/staff/customer_form.rb
+++ b/app/forms/staff/customer_form.rb
@@ -1,21 +1,36 @@
 class Staff::CustomerForm
   include ActiveModel::Model
 
-  attr_accessor :customer
+  attr_accessor :customer, :inputs_home_address, :inputs_work_address
   delegate :persisted?, :save, to: :customer
 
   def initialize(customer = nil)
     @customer = customer
     @customer ||= Customer.new(gender: "male")
+    self.inputs_home_address = @customer.home_address.present?
+    self.inputs_work_address = @customer.work_address.present?
     @customer.build_home_address unless @customer.home_address
     @customer.build_work_address unless @customer.work_address
   end
 
   def assign_attributes(params = {})
     @params = params
-      customer.assign_attributes(customer_params)
+    self.inputs_home_address = params[:inputs_home_address] == "1"
+    self.inputs_work_address = params[:inputs_work_address] == "1"
+
+    customer.assign_attributes(customer_params)
+      
+    if inputs_home_address
       customer.home_address.assign_attributes(home_address_params)
+    else
+      customer.home_address.mark_for_destruction
+    end
+      
+    if inputs_work_address
       customer.work_address.assign_attributes(work_address_params)
+    else
+      customer.work_address.mark_for_destruction
+    end
   end
   
   private def customer_params

--- a/app/javascript/packs/staff.js
+++ b/app/javascript/packs/staff.js
@@ -1,0 +1,6 @@
+require("@rails/ujs").start()
+require("turbolinks").start()
+require("@rails/activestorage").start()
+require("channels")
+
+import "../staff/customer_form.js";

--- a/app/javascript/staff/customer_form.js
+++ b/app/javascript/staff/customer_form.js
@@ -1,0 +1,24 @@
+function toggle_home_address_fields() {
+  const checked = 
+  $("input#form_inputs_home_address").prop("checked");
+  $("fieldset#home-address-fields input").prop("disabled", !checked);
+  $("fieldset#home-address-fields select").prop("disabled", !checked);
+}
+
+function toggle_work_address_fields() {
+  const checked = 
+  $("input#form_inputs_work_address").prop("checked");
+  $("fieldset#work-address-fields input").prop("disabled", !checked);
+  $("fieldset#work-address-fields select").prop("disabled", !checked);
+}
+
+$(document).on("ready turbolinks:load", () => {
+  toggle_home_address_fields();
+  toggle_work_address_fields();
+    $("input#form_inputs_home_address").on("click", () => {
+      toggle_home_address_fields();
+    });
+    $("input#form_inputs_work_address").on("click", () => {
+      toggle_work_address_fields();
+    });
+});

--- a/app/views/layouts/staff.html.erb
+++ b/app/views/layouts/staff.html.erb
@@ -6,7 +6,7 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "staff", media: "all", "data-turbolinks-track": "reload" %>
-    <%= javascript_pack_tag "application", "data-turbolinks-track": "reload" %>
+    <%= javascript_pack_tag "staff", "data-turbolinks-track": "reload" %>
   </head>
 
   <body>

--- a/app/views/staff/customers/_form.html.erb
+++ b/app/views/staff/customers/_form.html.erb
@@ -3,10 +3,18 @@
   <legend> 基本情報 </legend>
   <%= render "customer_fields", f: f %>
 </fieldset>
+<div class="check-boxes">
+  <%= f.check_box :inputs_home_address %>
+  <%= f.label :inputs_home_address, "自宅住所を入力する" %>
+</div>
 <fieldset id="home-address-fields">
   <legend> 自宅住所 </legend>
   <%= render "home_address_fields", f: f %>
 </fieldset>
+<div class="check-boxes">
+  <%= f.check_box :inputs_work_address %>
+  <%= f.label :inputs_work_address, "勤務先を入力する" %>
+</div>
 <fieldset id="work-address-fields">
   <legend> 勤務先 </legend>
   <%= render "work_address_fields", f: f %>

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,10 @@
-const { environment } = require('@rails/webpacker')
+const { environment } = require("@rails/webpacker")
 
+const webpack = require("webpack")
+  environment.plugins.prepend("Provide",
+    new webpack.ProvidePlugin({
+      $: "jquery/src/jquery",
+      jQuery: "jquery/src/jquery"
+    })
+  )
 module.exports = environment

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.3.0",
+    "jquery": "^3.6.0",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0"

--- a/spec/features/staff/customer_management_spec.rb
+++ b/spec/features/staff/customer_management_spec.rb
@@ -10,6 +10,26 @@ feature "職員による顧客管理" do
     login_as_staff_member(staff_member)
   end
 
+  scenario "職員が顧客(基本情報のみを追加する)" do
+    click_link "顧客管理"
+    first("div.links").click_link "新規登録"
+    fill_in "メールアドレス", with: "test@example.jp"
+    fill_in "パスワード", with: "pw"
+    fill_in "form_customer_family_name", with: "試験"
+    fill_in "form_customer_given_name", with: "花子"
+    fill_in "form_customer_family_name_kana", with: "シケン"
+    fill_in "form_customer_given_name_kana", with: "ハナコ"
+    fill_in "生年月日", with: "1970-01-01"
+    choose "女性"
+    click_button "登録"
+
+    new_customer = Customer.order(:id).last
+    expect(new_customer.email).to eq("test@example.jp")
+    expect(new_customer.birthday).to eq(Date.new(1970,1,1))
+    expect(new_customer.gender).to eq("female")
+    expect(new_customer.home_address).to be_nil
+    expect(new_customer.work_address).to be_nil
+  end
   scenario "職員が顧客、自宅住所、勤務先を追加する" do
     click_link "顧客管理"
       first("div.links").click_link "新規登録"
@@ -22,7 +42,7 @@ feature "職員による顧客管理" do
       fill_in "form_customer_given_name_kana", with: "ハナコ"
       fill_in "生年月日", with: "1970-01-01"
       choose "女性"
-
+      check "自宅住所を入力する"
       within("fieldset#home-address-fields") do
         fill_in "郵便番号", with: "1000001"
         select "東京都", from: "都道府県"
@@ -30,7 +50,7 @@ feature "職員による顧客管理" do
         fill_in "町域、番地等", with: "千代田 1-1-1"
         fill_in "建物名、部屋番号", with: "" 
       end
-
+      check "勤務先を入力する"
       within("fieldset#work-address-fields") do
         fill_in "会社名", with: "テスト"
         fill_in "部署名", with: ""

--- a/yarn.lock
+++ b/yarn.lock
@@ -3637,6 +3637,11 @@ jest-worker@^25.4.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jquery@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
+  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
+
 js-base64@^2.1.8:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"


### PR DESCRIPTION
customerの新規登録・更新時にaddress(home_address、work_addressともに)用のcheckboxにcheckをつけた時のみ、home_addressとwork_addressを入力出来る様に書き換えたため(checkboxを追加)、それに伴い条件を追加。